### PR TITLE
Modified "getGoals" endpoint  to be able to get goals by status.

### DIFF
--- a/src/api/getGoals/const_vars.js
+++ b/src/api/getGoals/const_vars.js
@@ -1,8 +1,45 @@
 
-const DFLT_LIMITDATE_ORDER=1; //Default order for limit_date in getGoals
+const PAGE_LIMIT = 10; //Number of goals per page
 
-const PAGE_LIMIT=10; //Number of goals per page
+const SGNDURL_LIMITDATE_MS = 1000 * 60 * 60; //1 hour in milliseconds for signed URL expiration
 
-const SGNDURL_LIMITDATE_MS=1000*60*60; //1 hour in milliseconds for signed URL expiration
+const DFLT_ORDER = 1; //Default order direction (1 = ascending, -1 = descending)
 
-module.exports = {DFLT_LIMITDATE_ORDER,PAGE_LIMIT,SGNDURL_LIMITDATE_MS};
+// ============ GOAL STATUS CONFIGURATIONS ============
+// Each status defines: filter (MongoDB query) and orderField (field to sort by)
+
+const GOALS_STATUS = {
+    DIFFUMING: 'diffuming',
+    EXPIRED: 'expired',
+    COMPLETED: 'completed'
+};
+
+const GOALS_STATUS_CONFIG = {
+    DIFFUMING: {
+        filter: { expired: false, completed: false },
+        orderField: 'limit_date'
+    },
+    EXPIRED: {
+        filter: { expired: true },
+        orderField: 'limit_date'
+    },
+    COMPLETED: {
+        filter: { completed: true },
+        orderField: 'completed_date'
+    }
+};
+
+const DFLT_GOAL_STATUS = GOALS_STATUS.DIFFUMING;
+
+// Valid status values for validation
+const VALID_GOAL_STATUSES = Object.values(GOALS_STATUS);
+
+module.exports = {
+    PAGE_LIMIT,
+    SGNDURL_LIMITDATE_MS,
+    DFLT_ORDER,
+    GOALS_STATUS,
+    GOALS_STATUS_CONFIG,
+    DFLT_GOAL_STATUS,
+    VALID_GOAL_STATUSES
+};

--- a/src/api/getGoals/service/getGoalsService.js
+++ b/src/api/getGoals/service/getGoalsService.js
@@ -1,22 +1,24 @@
-const {PAGE_LIMIT, SGNDURL_LIMITDATE_MS}=require("../const_vars.js");
+const {PAGE_LIMIT, GOALS_STATUS_CONFIG}=require("../const_vars.js");
 
 const {getGoals_errorHandler}=require("./error_handler.js");
 
 const { getGoals_fromDB,getGoal_originalImage_fromDB,add_imgsUrls,getSignedUrl } = require("./utils.js");
 
-async function getGoals_Service(page,limitDate_order){
+async function getGoals_Service(page, goalStatus, order){
     let goals=[];
     
+    // Get filter and orderField based on goalStatus
+    const { filter, orderField } = GOALS_STATUS_CONFIG[goalStatus];
+    
     try{
-        goals = await getGoals_fromDB(page,limitDate_order);
+        goals = await getGoals_fromDB(page, filter, orderField, order);
     } 
     catch(e){
         let user_error=await getGoals_errorHandler(e);
         return {error:user_error,data:null};
     }
     
-    // Add signedUrl to each goal
-    console.log(goals)
+    // Add signed URLs to each goal
     goals=add_imgsUrls(goals);
 
     //Know if there are more pages

--- a/src/api/getGoals/service/utils.js
+++ b/src/api/getGoals/service/utils.js
@@ -5,12 +5,13 @@ const {PAGE_LIMIT,SGNDURL_LIMITDATE_MS}=require("../const_vars.js");
 
 const {GoalModel}=require("../../../db/mongodb");
 
-async function getGoals_fromDB(page,limitDate_order){
+// Fetches goals from DB with filter and dynamic sort field
+async function getGoals_fromDB(page, filter, orderField, order){
     
     try {
-        return await GoalModel.find()
+        return await GoalModel.find(filter)
             .select('descr expired limit_date s3_imgName_latest completed completed_date s3_imgName_completed')
-            .sort({limit_date: limitDate_order})
+            .sort({ [orderField]: order })
             .skip((page-1)*PAGE_LIMIT)
             .limit(PAGE_LIMIT).lean();
     }

--- a/src/api/getGoals/validator.js
+++ b/src/api/getGoals/validator.js
@@ -2,11 +2,12 @@ const Joi = require("joi");
 
 const {DEFLT_API_ERRORS}=require("../../error_handling");
 
-const {DFLT_LIMITDATE_ORDER}=require("./const_vars.js");
+const {DFLT_ORDER, DFLT_GOAL_STATUS, VALID_GOAL_STATUSES}=require("./const_vars.js");
 
 const getGoals_ValSchema = Joi.object({
     page: Joi.number().integer().min(1).default(1),
-    limitDate_order: Joi.number().valid(1, -1).default(DFLT_LIMITDATE_ORDER)
+    goalStatus: Joi.string().valid(...VALID_GOAL_STATUSES).default(DFLT_GOAL_STATUS),
+    order: Joi.number().valid(1, -1).default(DFLT_ORDER)
 });
 
 const getGoal_originalImage_ValSchema = Joi.object({
@@ -23,9 +24,11 @@ function validate_getGoals(query) {
 
     return {error: null,
             queryData:{
-               page:value.page,
-               limitDate_order:value.limitDate_order}
-            };
+               page: value.page,
+               goalStatus: value.goalStatus,
+               order: value.order
+            }
+        };
 }
 
 function validate_getGoal_originalImage(params) {

--- a/src/controllers/goalsControllers.js
+++ b/src/controllers/goalsControllers.js
@@ -63,11 +63,11 @@ async function getGoals(req,res){
 
     if (error) {apiError_handler(error, res);return;}
     
-    let {page,limitDate_order}=queryData;
+    let {page, goalStatus, order}=queryData;
 
     // Call service
     let data;
-    ({error, data} = await getGoals_Service(page,limitDate_order));
+    ({error, data} = await getGoals_Service(page, goalStatus, order));
 
     if (error) {apiError_handler(error, res);return;}
 


### PR DESCRIPTION
-This allows an easier sectioning in the UI

-The current goals status are : 

- diffuming
- expired
- completed

Each status will have its own ordering fields internally. The user will only send order =  -1 or 1. The UI needs to inform the user what is he ordering by.